### PR TITLE
small fixes for component pool logs

### DIFF
--- a/src/source/core/ComponentPool.bs
+++ b/src/source/core/ComponentPool.bs
@@ -80,13 +80,13 @@ namespace mc
 
       if pool.freeComponentsById.count() = 0
         ' ? ">>>> RAN OUT OF " ; componentType
-        m.log.warn("ran out of components getting type :", componentType)
-
+        m.log.warn("no free components of type :", componentType)
         if m.isCreateMoreEnabled
-          m.log.warn("creating", m.numberOfComponentsToCreateWhenDry, "more", componentType, "components")
           if numToCreateIfDry = -1
             numToCreateIfDry = m.numberOfComponentsToCreateWhenDry
           end if
+          m.log.warn("creating", numToCreateIfDry, "more", componentType, "components")
+
           numberOfComponents = m.numberOfComponents
           for i = 0 to numToCreateIfDry
             component = m.createComponent(componentType)

--- a/src/source/ml/RowItemViewManager.bs
+++ b/src/source/ml/RowItemViewManager.bs
@@ -121,7 +121,7 @@ namespace ml
           if cell = invalid
             settings = ml.listMixin.getCellSettings(m.owner.content, m.content, item)
             ' ? "GETTING CELL " ; id ; " " ; settings.compName ; " " ; m.__classname
-            cell = m.componentPool@.getComponent(settings.compName)
+            cell = m.componentPool@.getComponent(settings.compName, 1)
 
             if cell = invalid
               cell = m.previousRendereredByContentId[itemId]


### PR DESCRIPTION
log the actual passed number of components to be created instead of the default one.create one more cell for row item view manager instead of default 10