### PR TITLE
Fix build badge and readme formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## A development platform for building roku channels in brighterscript.
+# A development platform for building roku channels in brighterscript
 
 [![build](https://img.shields.io/github/actions/workflow/status/georgejecook/maestro-roku/build.yml?logo=github&branch=master)](https://github.com/georgejecook/maestro-roku/actions/workflows/build.yml)
 [![GitHub](https://img.shields.io/github/release/georgejecook/maestro-roku.svg?style=flat-square)](https://github.com/georgejecook/maestro-roku/releases)
@@ -6,38 +6,38 @@
 
 ## Why maestro?
 
-### Maestro Makes roku development easier, especially for experienced software engineers from other platforms:
+### Maestro Makes roku development easier, especially for experienced software engineers from other platforms
 
 I believe that experienced developers from android, ios, c#, web, node, etc, should be able to be productive on a roku app in no more than a week, just as they would on any other platform. So I wrote maestro to make that possible.
 
 Maestro is built to:
 
- - Raise velocity
- - Increase productivity
- - Reduce learning
- - Simply cross-skilling
- - Make roku development more fun
- - Produce roku apps that can be maintained by non roku developer
- - Produce roku apps that can be unit tested easily
- - Write code that can be tested and breakpoint debugged, outside of SG views (which are slow as hell, and prone to crashing when breakpoint debugging)
+- Raise velocity
+- Increase productivity
+- Reduce learning
+- Simply cross-skilling
+- Make roku development more fun
+- Produce roku apps that can be maintained by non roku developer
+- Produce roku apps that can be unit tested easily
+- Write code that can be tested and breakpoint debugged, outside of SG views (which are slow as hell, and prone to crashing when breakpoint debugging)
 
 ## Quick start
 
-  - Clone the [sample project](https://github.com/georgejecook/maestro-roku-sample) and follow the instructions there
-
-
+- Clone the [sample project](https://github.com/georgejecook/maestro-roku-sample) and follow the instructions there
 
 ## Docs
+
 Maestro-roku docs can be found [here](./docs/index.md)
 
-
-## IMPORTANT!! ropm hook!
+## IMPORTANT!! ropm hook
 
 Because of the way that maestro plugin generates certain files, ropm ~can~ *will* cause errors when you install maestro. You will have to include a script to fix any of these broken files, and run it after you ropm hook.
 
 ### files
+
 #### scripts/maestro-ropm-hook.js
-```
+
+```js
 /* eslint-disable github/array-foreach */
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/no-require-imports */
@@ -63,7 +63,9 @@ try {
 ```
 
 #### package.json
-change your ropm task, as follows. in package.json, scripts:
-```
+
+Change your ropm task, as follows. in package.json, scripts:
+
+```json
 "ropm": "node scripts/maestro-ropm-hook.js ropm copy",
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ## A development platform for building roku channels in brighterscript.
 
-
-[![build](https://img.shields.io/github/workflow/status/georgejecook/maestro-roku/build.svg?logo=github)](https://github.com/georgejecook/maestro-roku/actions?query=workflow%3Abuild)
+[![build](https://img.shields.io/github/actions/workflow/status/georgejecook/maestro-roku/build.yml?logo=github&branch=master)](https://github.com/georgejecook/maestro-roku/actions/workflows/build.yml)
 [![GitHub](https://img.shields.io/github/release/georgejecook/maestro-roku.svg?style=flat-square)](https://github.com/georgejecook/maestro-roku/releases)
 [![NPM Version](https://badge.fury.io/js/maestro-roku.svg?style=flat)](https://npmjs.org/package/maestro-roku)
 


### PR DESCRIPTION
## Changes
- Fixes build badge - see [here ](https://github.com/badges/shields/issues/8671) for more information
- Fixes build badge link - now takes you to the `build.yml` workflow results as intended
- Fix markdown formatting (linting errors from vscode extension)