### PR TITLE
Proposal: Fix Registry and Serialize Return Values

### DIFF
--- a/src/source/core/Registry.bs
+++ b/src/source/core/Registry.bs
@@ -35,6 +35,8 @@ namespace mc
         m.log.error("Call to roRegistrySection.flush() failed.")
         return false
       end if
+
+      return true
     end function
 
     public function delete(sectionName as string, key as string) as void
@@ -44,13 +46,13 @@ namespace mc
       if section.exists(key)
         success = section.delete(key)
         if not success
-          m.log.error("Failed to delete key '" + key + "' from registry section '" + sectionName + "'")
+          m.log.error(`Failed to delete key '${key}' from registry section '${sectionName}'`)
           return false
         end if
-      else
-        m.log.warn("Attempted to delete registry section " + sectionName + ", but registry section does not exist.")
-        return true ' return as success even if registry doesn't exist, as this technically fulfills goal of a delete() call
       end if
+
+      m.log.warn(`Attempted to delete registry section ${sectionName}, but registry section does not exist.`)
+      return true ' return as success even if registry doesn't exist, as this technically fulfills goal of a delete() call
     end function
 
     public function readAll() as object
@@ -92,7 +94,7 @@ namespace mc
               if not section.write(key, formatJson(value))
                 success = false ' flip success=false if there is any failure; subsequent successes do not negate failure
                 if not success
-                  m.log.error("Failed to write registry data for registry section '" + sectionName + "', key '" + key + "'")
+                  m.log.error(`Failed to write registry data for registry section '${sectionName}', key '${key}'`)
                 end if
               end if
             end for
@@ -124,7 +126,7 @@ namespace mc
       for each sectionName in sections
         if not registry.delete(sectionName)
           success = false
-          m.log.error("Failed to delete registry section '" + sectionName + "'")
+          m.log.error(`Failed to delete registry section '${sectionName}'`)
         end if
       end for
 

--- a/src/source/core/Registry.bs
+++ b/src/source/core/Registry.bs
@@ -23,8 +23,18 @@ namespace mc
       sectionName = lcase(sectionName)
       key = lcase(key)
       section = createObject("roRegistrySection", sectionName)
-      section.write(key, formatJson(value))
-      section.flush()
+
+      success = section.write(key, formatJson(value))
+      if not success
+        m.log.error("Call to roRegistrySection.write() failed.")
+        return false
+      end if
+
+      success = section.flush()
+      if not success
+        m.log.error("Call to roRegistrySection.flush() failed.")
+        return false
+      end if
     end function
 
     public function delete(sectionName as string, key as string) as void
@@ -32,7 +42,14 @@ namespace mc
       key = lcase(key)
       section = createObject("roRegistrySection", sectionName)
       if section.exists(key)
-        section.delete(key)
+        success = section.delete(key)
+        if not success
+          m.log.error("Failed to delete key '" + key + "' from registry section '" + sectionName + "'")
+          return false
+        end if
+      else
+        m.log.warn("Attempted to delete registry section " + sectionName + ", but registry section does not exist.")
+        return true ' return as success even if registry doesn't exist, as this technically fulfills goal of a delete() call
       end if
     end function
 
@@ -56,6 +73,7 @@ namespace mc
     end function
 
     public function writeAll(data as object) as void
+      success = true
       registry = createObject("roRegistry")
 
       if data <> invalid and type(data) = "roAssociativeArray"
@@ -70,33 +88,53 @@ namespace mc
             for each key in sectionData
               value = sectionData[key]
               key = lcase(`${key}`)
-              section.write(key, formatJson(value))
+
+              if not section.write(key, formatJson(value))
+                success = false ' flip success=false if there is any failure; subsequent successes do not negate failure
+                if not success
+                  m.log.error("Failed to write registry data for registry section '" + sectionName + "', key '" + key + "'")
+                end if
+              end if
             end for
 
           end if
-          section.flush()
+
+          if not section.flush()
+            success = false
+            m.log.error("Call to roRegistrySection.flush() failed.")
+          end if
 
         end for
 
       end if
 
-      registry.flush()
+      if not registry.flush()
+        success = false
+        m.log.error("Call to roRegistry.flush() failed.")
+      end if
+
+      return success
     end function
 
     public function deleteAll() as void
+      success = true
       registry = createObject("roRegistry")
       sections = registry.getSectionList()
 
       for each sectionName in sections
-        registry.delete(sectionName)
+        if not registry.delete(sectionName)
+          success = false
+          m.log.error("Failed to delete registry section '" + sectionName + "'")
+        end if
       end for
+
+      return success
     end function
 
     function writeSerializable(section as string, key as string, serializable as object) as boolean
       data = mc.utils.Serialization.serialize(serializable)
       if data <> invalid
-        m.write(section, key, data)
-        return true
+        return m.write(section, key, data)
       else
         m.log.warn("asked to write from non-serializebale object")
         return false

--- a/src/source/core/Registry.bs
+++ b/src/source/core/Registry.bs
@@ -19,7 +19,7 @@ namespace mc
       end if
     end function
 
-    public function write(sectionName as string, key as string, value as dynamic) as void
+    public function write(sectionName as string, key as string, value as dynamic) as boolean
       sectionName = lcase(sectionName)
       key = lcase(key)
       section = createObject("roRegistrySection", sectionName)
@@ -39,7 +39,7 @@ namespace mc
       return true
     end function
 
-    public function delete(sectionName as string, key as string) as void
+    public function delete(sectionName as string, key as string) as boolean
       sectionName = lcase(sectionName)
       key = lcase(key)
       section = createObject("roRegistrySection", sectionName)
@@ -74,7 +74,7 @@ namespace mc
       return data
     end function
 
-    public function writeAll(data as object) as void
+    public function writeAll(data as object) as boolean
       success = true
       registry = createObject("roRegistry")
 
@@ -118,7 +118,7 @@ namespace mc
       return success
     end function
 
-    public function deleteAll() as void
+    public function deleteAll() as boolean
       success = true
       registry = createObject("roRegistry")
       sections = registry.getSectionList()
@@ -138,7 +138,7 @@ namespace mc
       if data <> invalid
         return m.write(section, key, data)
       else
-        m.log.warn("asked to write from non-serializebale object")
+        m.log.warn("asked to write from non-serializeable object")
         return false
       end if
     end function
@@ -148,7 +148,7 @@ namespace mc
         data = m.read(section, key)
         return mc.utils.Serialization.deSerialize(data, serializable)
       else
-        m.log.warn("asked to read into non-serializebale object")
+        m.log.warn("asked to read into non-serializeable object")
       end if
       return false
     end function

--- a/src/source/core/Serialization.bs
+++ b/src/source/core/Serialization.bs
@@ -7,7 +7,7 @@ namespace mc.utils.Serialization
       if type(serializable) = "roSGNode"
         data = serializable@.serialize()
         if not mc.isAACompatible(data)
-          m.log.error("received non aa value when serialize - cannot proceed")
+          m.log.error("Expected AssociativeArray value. Received type of " + type(data) + " instead.")
           return invalid
         end if
         data._serializationType = serializable.subType()
@@ -18,7 +18,7 @@ namespace mc.utils.Serialization
         return serializable.serialize()
       end if
     else
-      m.log.warn("asked to serialize non-serializebale object")
+      m.log.error("Expected serializable value. Received type of " + type(data) + " instead.")
     end if
     return invalid
   end function


### PR DESCRIPTION
Creating this PR to ensure that roRegistry and roRegistrySection function return values which indicate success/failure of registry calls are passed through to maestro function callers and error logging.

I have not updated the unit tests yet. Wanted to verify that this code change proposal is otherwise acceptable before putting more time into it.